### PR TITLE
Implement the complement to checkAccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postversion": "git push --follow-tags",
     "prepublish": "npm test && npm run build",
     "standard": "standard *.js src/*.js",
-    "tape": "tape test/unit/check-access-test.js",
+    "tape": "tape test/unit/check-access-test.js test/unit/access-denied-test.js",
     "test": "npm run standard && npm run tape"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "^6.0"
   },
   "description": "Web Access Control check access function",
-  "main": "./lib/index",
+  "main": "./lib/acl-check",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "acl-test",
+  "name": "acl-check",
   "version": "0.0.1",
   "engines": {
     "node": "^6.0"

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -32,7 +32,7 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
       console.log('  Append required and Write allowed. OK')
     } else {
       console.log('  MODE REQUIRED NOT ALLOWED:' + mode)
-      ok = true
+      ok = 'Forbidden'
     }
   })
   return ok

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -24,7 +24,7 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
   console.log(`accessDenied: checking access to ${doc} by ${agent} and origin ${origin}`)
   let modeURIorReasons = modesAllowed(kb, doc, directory, aclDoc, agent, origin, trustedOrigins)
   let ok = false
-  console.log(`accessDenied: modeURIorReasons: ${modeURIorReasons.size}`)
+  console.log('accessDenied: modeURIorReasons: ' + JSON.stringify(Array.from(modeURIorReasons)))
   modesRequired.forEach(mode => {
     console.log(` checking ` + mode)
     if (modeURIorReasons.has(mode.uri)) {
@@ -32,8 +32,8 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
     } else if (mode.sameTerm(ACL('Append')) && modeURIorReasons.has(ACL('Write').uri)) {
       console.log('  Append required and Write allowed. OK')
     } else {
-      console.log('  MODE REQUIRED NOT ALLOWED:' + mode)
-      ok = modeURIorReasons.pop || 'Forbidden'
+      ok = modeURIorReasons.values().next().value || 'Forbidden'
+      console.log('  MODE REQUIRED NOT ALLOWED: ' + mode + ' Denying with ' + ok)
     }
   })
   return ok

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -124,5 +124,6 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, modesRequired, origin,
 }
 
 module.exports.checkAccess = checkAccess
+module.exports.accessDenied = accessDenied
 module.exports.modesAllowed = modesAllowed
 module.exports.publisherTrustedApp = publisherTrustedApp

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -21,9 +21,10 @@ function publisherTrustedApp (kb, doc, aclDoc, modesRequired, origin, docAuths) 
 }
 
 function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
+  console.log(`accessDenied: checking access to ${doc} by ${agent} and origin ${origin}`)
   let modeURIs = modesAllowed(kb, doc, directory, aclDoc, agent, origin, trustedOrigins)
   let ok = false
-  console.log(`CheckAccess: modeURIs: ${modeURIs.size}`)
+  console.log(`accessDenied: modeURIs: ${modeURIs.size}`)
   modesRequired.forEach(mode => {
     console.log(` checking ` + mode)
     if (modeURIs.has(mode.uri)) {
@@ -46,8 +47,8 @@ function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, 
   return !Boolean(accessDenied(kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins))
 }
 
-function modesAllowed (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
-  console.log(`modesAllowed: checking access to ${doc} by ${agent}`)
+function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins) {
+  console.log(`modesAllowed: checking access to ${doc} by ${agent} and origin ${origin}`)
   var auths
   if (!directory) { // Normal case, ACL for a file
     auths = kb.each(null, ACL('accessTo'), doc, aclDoc)

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -33,6 +33,11 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
       console.log('  Append required and Write allowed. OK')
     } else {
       ok = modeURIorReasons.values().next().value || 'Forbidden'
+      if (ok.startsWith('http')) {
+	// Then, the situation is that one mode has failed, the other
+	// has passed, and we get URI of the one that passed, but that's not a good error
+        ok = 'All Required Access Modes Not Granted'
+      }
       console.log('  MODE REQUIRED NOT ALLOWED: ' + mode + ' Denying with ' + ok)
     }
   })

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -20,13 +20,9 @@ function publisherTrustedApp (kb, doc, aclDoc, modesRequired, origin, docAuths) 
   // modesRequired.every(mode => appAuths.some(auth => kb.holds(auth, ACL('mode'), mode, aclDoc)))
 }
 
-/* Function checkAccess
-** @param kb A quadstore
-** @param doc the resource (A named node) or directory for which ACL applies
-*/
-function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
+function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
   let modeURIs = modesAllowed(kb, doc, directory, aclDoc, agent, origin, trustedOrigins)
-  let ok = true
+  let ok = false
   console.log(`CheckAccess: modeURIs: ${modeURIs.size}`)
   modesRequired.forEach(mode => {
     console.log(` checking ` + mode)
@@ -36,10 +32,18 @@ function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, 
       console.log('  Append required and Write allowed. OK')
     } else {
       console.log('  MODE REQUIRED NOT ALLOWED:' + mode)
-      ok = false
+      ok = true
     }
   })
   return ok
+}
+
+/* Function checkAccess
+** @param kb A quadstore
+** @param doc the resource (A named node) or directory for which ACL applies
+*/
+function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
+  return !Boolean(accessDenied(kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins))
 }
 
 function modesAllowed (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -22,18 +22,18 @@ function publisherTrustedApp (kb, doc, aclDoc, modesRequired, origin, docAuths) 
 
 function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
   console.log(`accessDenied: checking access to ${doc} by ${agent} and origin ${origin}`)
-  let modeURIs = modesAllowed(kb, doc, directory, aclDoc, agent, origin, trustedOrigins)
+  let modeURIorReasons = modesAllowed(kb, doc, directory, aclDoc, agent, origin, trustedOrigins)
   let ok = false
-  console.log(`accessDenied: modeURIs: ${modeURIs.size}`)
+  console.log(`accessDenied: modeURIorReasons: ${modeURIorReasons.size}`)
   modesRequired.forEach(mode => {
     console.log(` checking ` + mode)
-    if (modeURIs.has(mode.uri)) {
+    if (modeURIorReasons.has(mode.uri)) {
       console.log('  Mode required and allowed:' + mode)
-    } else if (mode.sameTerm(ACL('Append')) && modeURIs.has(ACL('Write').uri)) {
+    } else if (mode.sameTerm(ACL('Append')) && modeURIorReasons.has(ACL('Write').uri)) {
       console.log('  Append required and Write allowed. OK')
     } else {
       console.log('  MODE REQUIRED NOT ALLOWED:' + mode)
-      ok = 'Forbidden'
+      ok = modeURIorReasons.pop || 'Forbidden'
     }
   })
   return ok
@@ -94,34 +94,39 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
     return kb.holds(auth, ACL('origin'), origin, aclDoc)
   }
 
-  function agentAndAppOK (auth) {
+  function agentAndAppFail (auth) {
     if (!agentOrGroupOK(auth, agent)) {
       console.log('     The agent/group/public check fails')
-      return false
+      return 'User Unauthorized'
     }
     if (!origin) {
       console.log('     Origin check not needed: no origin.')
-      return true
+      return false
     }
     if (originOK(auth, origin)) {
       console.log('     Origin check succeeded.')
-      return true
+      return false
     }
     console.log('     Origin check FAILED. Origin not trusted.')
-    return false // @@ look for other trusted apps
+    return 'Origin Unauthorized' // @@ look for other trusted apps
   }
 
-  auths = auths.filter(agentAndAppOK)
-  console.log('  auths with good who and what: ' + auths.length)
-  var modeURIs = new Set()
+  var modeURIorReasons = new Set()
+
   auths.forEach(auth => {
-    let modes = kb.each(auth, ACL('mode'), null, aclDoc)
-    modes.forEach(mode => {
-      console.log('      Mode allowed: ' + mode)
-      modeURIs.add(mode.uri)
-    })
+    let agentAndAppStatus = agentAndAppFail(auth)
+    if (agentAndAppStatus) {
+      console.log('      Check failed: ' + agentAndAppStatus)
+      modeURIorReasons.add(agentAndAppStatus)
+    } else {
+      let modes = kb.each(auth, ACL('mode'), null, aclDoc)
+      modes.forEach(mode => {
+        console.log('      Mode allowed: ' + mode)
+        modeURIorReasons.add(mode.uri)
+      })
+    }
   })
-  return modeURIs
+  return modeURIorReasons
 }
 
 module.exports.checkAccess = checkAccess

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -17,7 +17,7 @@ const bob = $rdf.sym('https://bob.example.com/#me')
 const malory = $rdf.sym('https://someone.else.example.com/')
 
 // Append access implied by Write acecss
-test('aclCheck checkAccess() test - Append access implied by Write acecss', t => {
+test('aclCheck accessDenied() test - Append access implied by Write acecss', t => {
   let resource = $rdf.sym('https://alice.example.com/docs/file1')
   let aclUrl = 'https://alice.example.com/docs/.acl'
   let aclDoc = $rdf.sym(aclUrl)
@@ -43,7 +43,7 @@ test('aclCheck checkAccess() test - Append access implied by Write acecss', t =>
 })
 
 // Straight ACL access test
-test('acl-check checkAccess() test - accessTo', function (t) {
+test('acl-check accessDenied() test - accessTo', function (t) {
   let container = $rdf.sym('https://alice.example.com/docs/')
   let containerAclUrl = 'https://alice.example.com/docs/.acl'
   let containerAcl = $rdf.sym(containerAclUrl)
@@ -59,12 +59,13 @@ test('acl-check checkAccess() test - accessTo', function (t) {
 
   var result = aclLogic.accessDenied(store, container, null, containerAcl, bob, [ ACL('Write')])
   t.ok(result, 'Bob Should not have access')
+  t.equal(result, 'Forbidden', 'Correct reason')
 
   t.end()
 })
 
 // Inheriting permissions from directory defaults
-test('acl-check checkAccess() test - default/inherited', function (t) {
+test('acl-check accessDenied() test - default/inherited', function (t) {
   let container = $rdf.sym('https://alice.example.com/docs/')
   let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
   let file1 = $rdf.sym('https://alice.example.com/docs/file1')
@@ -101,7 +102,7 @@ test('acl-check checkAccess() test - default/inherited', function (t) {
 
 
 // Inheriting permissions from directory defaults
-test('acl-check checkAccess() test - default/inherited', function (t) {
+test('acl-check accessDenied() test - default/inherited', function (t) {
   let container = $rdf.sym('https://alice.example.com/docs/')
   let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
   let file1 = $rdf.sym('https://alice.example.com/docs/file1')
@@ -130,32 +131,8 @@ test('acl-check checkAccess() test - default/inherited', function (t) {
   t.end()
 })
 
-////////////////////////////  Non-anonymoud versions
-// Append access implied by Write acecss -PUBLIC
-test('aclCheck checkAccess() test - Append access implied by Public Write acecss', t => {
-  let resource = $rdf.sym('https://alice.example.com/docs/file1')
-  let aclUrl = 'https://alice.example.com/docs/.acl'
-  let aclDoc = $rdf.sym(aclUrl)
-
-  const store = $rdf.graph() // Quad store
-  const ACLtext = prefixes +
-  ` <#auth> a acl:Authorization;
-    acl:mode acl:Write;
-    acl:agentClass acl:AuthenticatedAgent;
-    acl:accessTo <${resource.uri}> .
-  `
-  $rdf.parse(ACLtext, store, aclUrl, 'text/turtle')
-
-  const modesRequired = [ ACL('Append')]
-
-  let result = aclLogic.checkAccess(store, resource, null, aclDoc, alice, modesRequired)
-  t.ok(result, 'Alice should have Append access implied by Write access - AuthenticatedAgent')
-
-  t.end()
-})
-
 // Straight ACL access test
-test('acl-check checkAccess() test - accessTo', function (t) {
+test('acl-check accessDenied() test - accessTo', function (t) {
   let container = $rdf.sym('https://alice.example.com/docs/')
   let containerAclUrl = 'https://alice.example.com/docs/.acl'
   let containerAcl = $rdf.sym(containerAclUrl)
@@ -182,7 +159,7 @@ test('acl-check checkAccess() test - accessTo', function (t) {
 })
 
 // Inheriting permissions from directory defaults
-test('acl-check checkAccess() test - default/inherited', function (t) {
+test('acl-check accessDenied() test - default/inherited', function (t) {
   let container = $rdf.sym('https://alice.example.com/docs/')
   let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
   let file1 = $rdf.sym('https://alice.example.com/docs/file1')

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -1,0 +1,210 @@
+'use strict'
+
+const test = require('tape')
+const aclLogic = require('../../src/acl-check')
+const $rdf = require('rdflib')
+
+const ACL = $rdf.Namespace('http://www.w3.org/ns/auth/acl#')
+const FOAF = $rdf.Namespace('http://xmlns.com/foaf/0.1/')
+
+const prefixes = `@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix alice: <https://alice.example.com/#>.
+@prefix bob: <https://bob.example.com/#>.
+`
+const alice = $rdf.sym('https://alice.example.com/#me')
+const bob = $rdf.sym('https://bob.example.com/#me')
+const malory = $rdf.sym('https://someone.else.example.com/')
+
+// Append access implied by Write acecss
+test('aclCheck checkAccess() test - Append access implied by Write acecss', t => {
+  let resource = $rdf.sym('https://alice.example.com/docs/file1')
+  let aclUrl = 'https://alice.example.com/docs/.acl'
+  let aclDoc = $rdf.sym(aclUrl)
+
+  const store = $rdf.graph() // Quad store
+  const ACLtext = prefixes +
+  ` <#auth> a acl:Authorization;
+    acl:mode acl:Write;
+    acl:agent alice:me;
+    acl:accessTo <${resource.uri}> .
+  `
+  $rdf.parse(ACLtext, store, aclUrl, 'text/turtle')
+
+  const agent = alice
+  const directory = null
+  const modesRequired = [ ACL('Append')]
+  const trustedOrigins = null
+  const origin = null
+
+  const result = !aclLogic.accessDenied(store, resource, directory, aclDoc, agent, modesRequired, origin, trustedOrigins)
+  t.ok(result, 'Alice should have Append access implied by Write access')
+  t.end()
+})
+
+// Straight ACL access test
+test('acl-check checkAccess() test - accessTo', function (t) {
+  let container = $rdf.sym('https://alice.example.com/docs/')
+  let containerAclUrl = 'https://alice.example.com/docs/.acl'
+  let containerAcl = $rdf.sym(containerAclUrl)
+
+  const store = $rdf.graph() // Quad store
+  const ACLtext = prefixes +
+  ` <#auth> a acl:Authorization;
+    acl:mode acl:Read, acl:Write;
+    acl:agent alice:me;
+    acl:accessTo <${container.uri}> .
+  `
+  $rdf.parse(ACLtext, store, containerAclUrl, 'text/turtle')
+
+  var result = aclLogic.accessDenied(store, container, null, containerAcl, bob, [ ACL('Write')])
+  t.ok(result, 'Bob Should not have access')
+
+  t.end()
+})
+
+// Inheriting permissions from directory defaults
+test('acl-check checkAccess() test - default/inherited', function (t) {
+  let container = $rdf.sym('https://alice.example.com/docs/')
+  let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
+  let file1 = $rdf.sym('https://alice.example.com/docs/file1')
+  let file2 = $rdf.sym('https://alice.example.com/docs/stuff/file2')
+  var result
+  const store = $rdf.graph()
+  /*
+  let ACLtext = prefixes + ` <#auth> a acl:Authorization;
+    acl:mode acl:Read;
+    acl:agent bob:me;
+    acl:accessTo <${file1.uri}> .
+`
+  $rdf.parse(ACLtext, store, containerAcl.uri, 'text/turtle')
+*/
+  let containerAclText = prefixes + ` <#auth> a acl:Authorization;
+      acl:mode acl:Read;
+      acl:agent alice:me;
+      acl:default <${container.uri}> .
+`
+  $rdf.parse(containerAclText, store, containerAcl.uri, 'text/turtle')
+
+  result = !aclLogic.accessDenied(store, file1, container, containerAcl, alice, [ ACL('Read')])
+  t.ok(result, 'Alice should have Read acces inherited')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Read')])
+  t.ok(result, 'Alice should have Read acces inherited 2')
+
+  result = aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Write')])
+  t.ok(result, 'Alice should NOT have Write acces inherited')
+
+  t.end()
+})
+
+
+
+// Inheriting permissions from directory defaults
+test('acl-check checkAccess() test - default/inherited', function (t) {
+  let container = $rdf.sym('https://alice.example.com/docs/')
+  let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
+  let file1 = $rdf.sym('https://alice.example.com/docs/file1')
+  let file2 = $rdf.sym('https://alice.example.com/docs/stuff/file2')
+  var result
+  const store = $rdf.graph()
+  /*
+  let ACLtext = prefixes + ` <#auth> a acl:Authorization;
+    acl:mode acl:Read;
+    acl:agent bob:me;
+    acl:accessTo <${file1.uri}> .
+    `
+  $rdf.parse(ACLtext, store, containerAcl.uri, 'text/turtle')
+*/
+  let containerAclText = prefixes + ` <#auth> a acl:Authorization;
+      acl:mode acl:Read;
+      acl:agentClass foaf:Agent;
+      acl:default <${container.uri}> .
+`
+  $rdf.parse(containerAclText, store, containerAcl.uri, 'text/turtle')
+  console.log('@@' + containerAclText + '@@@')
+
+  result = aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Write')])
+  t.ok(result, 'Alice should NOT have write acces inherited  - Public')
+
+  t.end()
+})
+
+////////////////////////////  Non-anonymoud versions
+// Append access implied by Write acecss -PUBLIC
+test('aclCheck checkAccess() test - Append access implied by Public Write acecss', t => {
+  let resource = $rdf.sym('https://alice.example.com/docs/file1')
+  let aclUrl = 'https://alice.example.com/docs/.acl'
+  let aclDoc = $rdf.sym(aclUrl)
+
+  const store = $rdf.graph() // Quad store
+  const ACLtext = prefixes +
+  ` <#auth> a acl:Authorization;
+    acl:mode acl:Write;
+    acl:agentClass acl:AuthenticatedAgent;
+    acl:accessTo <${resource.uri}> .
+  `
+  $rdf.parse(ACLtext, store, aclUrl, 'text/turtle')
+
+  const modesRequired = [ ACL('Append')]
+
+  let result = aclLogic.checkAccess(store, resource, null, aclDoc, alice, modesRequired)
+  t.ok(result, 'Alice should have Append access implied by Write access - AuthenticatedAgent')
+
+  t.end()
+})
+
+// Straight ACL access test
+test('acl-check checkAccess() test - accessTo', function (t) {
+  let container = $rdf.sym('https://alice.example.com/docs/')
+  let containerAclUrl = 'https://alice.example.com/docs/.acl'
+  let containerAcl = $rdf.sym(containerAclUrl)
+
+  const store = $rdf.graph() // Quad store
+  const ACLtext = prefixes +
+  ` <#auth> a acl:Authorization;
+    acl:mode acl:Read, acl:Write;
+    acl:agentClass acl:AuthenticatedAgent;
+    acl:accessTo <${container.uri}> .
+  `
+  $rdf.parse(ACLtext, store, containerAclUrl, 'text/turtle')
+
+  var result = aclLogic.accessDenied(store, container, null, containerAcl, null, [ ACL('Read')])
+  t.ok(result, 'Anonymous should NOT have Read acces to public thing - AuthenticatedAgent')
+
+  result = aclLogic.accessDenied(store, container, null, containerAcl, null, [ ACL('Write')])
+  t.ok(result, 'Anonymous should NOT have Write acces - AuthenticatedAgent')
+
+  result = !aclLogic.accessDenied(store, container, null, containerAcl, bob, [ ACL('Write')])
+  t.ok(result, 'Bob should have Write acces to public write - AuthenticatedAgent')
+
+  t.end()
+})
+
+// Inheriting permissions from directory defaults
+test('acl-check checkAccess() test - default/inherited', function (t) {
+  let container = $rdf.sym('https://alice.example.com/docs/')
+  let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
+  let file1 = $rdf.sym('https://alice.example.com/docs/file1')
+  let file2 = $rdf.sym('https://alice.example.com/docs/stuff/file2')
+  var result
+  const store = $rdf.graph()
+  let ACLtext = prefixes + ` <#auth> a acl:Authorization;
+    acl:mode acl:Read;
+    acl:agent bob:me;
+    acl:accessTo <${file1.uri}> .
+`
+  $rdf.parse(ACLtext, store, containerAcl.uri, 'text/turtle')
+
+  let containerAclText = prefixes + ` <#auth> a acl:Authorization;
+      acl:mode acl:Read;
+      acl:agentClass acl:AuthenticatedAgent;
+      acl:default <${container.uri}> .
+`
+  $rdf.parse(containerAclText, store, containerAcl.uri, 'text/turtle')
+
+  result = aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Write')])
+  t.ok(result, 'Alice should NOT have write acces inherited  - AuthenticatedAgent')
+
+  t.end()
+})

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -330,7 +330,7 @@ test('aclCheck accessDenied() test - Various access rules', t => {
 
   result = aclLogic.accessDenied(store, resource, directory, aclDoc, agent, modesRequired, origin, trustedOrigins)
   t.ok(result, 'Alice should not have Read and Write access with authorized origin, both modes')
-  t.equal(result, 'User Unauthorized', 'Correct reason')
+  t.equal(result, 'All Required Access Modes Not Granted', 'Correct reason')
 
   result = aclLogic.accessDenied(store, resource, directory, aclDoc, agent, modesRequired, malorigin, trustedOrigins)
   t.ok(result, 'Mallorys app should not have Read and Write access with false origin, both modes')

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -59,7 +59,7 @@ test('acl-check accessDenied() test - accessTo', function (t) {
 
   var result = aclLogic.accessDenied(store, container, null, containerAcl, bob, [ ACL('Write')])
   t.ok(result, 'Bob Should not have access')
-  t.equal(result, 'Forbidden', 'Correct reason')
+  t.equal(result, 'User Unauthorized', 'Correct reason')
 
   t.end()
 })


### PR DESCRIPTION
As previously mentioned, to allow for the reasons for rejection to be communicated to the client as wanted in https://github.com/solid/node-solid-server/issues/468 , and maintain a single responsibility module, I suggested in #2  that the easiest was to implement the complement to `checkAccess`, i.e. `accessDenied`. This patch does that. It also adds quite a few more tests, and checks some more corner cases, one that caused me a some pain. 

Please poke!