### PR TITLE
Change group-related predicates

### DIFF
--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -87,7 +87,7 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
       return true
     }
     if (kb.each(auth, ACL('agentGroup'), null, aclDoc).some(
-      group => kb.holds(agent, VCARD('member'), group, group.doc()))) {
+      group => kb.holds(group, VCARD('hasMember'), agent, group.doc()))) {
       console.log('    Agent is member of group which has accees.')
       return true
     }

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -86,7 +86,7 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
       console.log('    Agent explicitly authenticated.')
       return true
     }
-    if (kb.each(auth, ACL('accessToGroup'), null, aclDoc).some(
+    if (kb.each(auth, ACL('agentGroup'), null, aclDoc).some(
       group => kb.holds(agent, VCARD('member'), group, group.doc()))) {
       console.log('    Agent is member of group which has accees.')
       return true


### PR DESCRIPTION
I couldn't find `acl:accessToGroup` neither in the namespace document, nor the spec or the current code, so I assume this is a glitch? `acl:agentGroup` is the predicate, right?