### PR TITLE
Succeed when an origin is defined, but no acl:origin is set

### DIFF
--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -97,7 +97,7 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
   } // Agent or group
 
   function originOK (auth, origin) {
-    return kb.holds(auth, ACL('origin'), origin, aclDoc)
+    return kb.holds(auth, ACL('origin'), origin, aclDoc) || !kb.holds(auth, ACL('origin'), null, aclDoc)
   }
 
   function agentAndAppFail (auth) {

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -221,6 +221,38 @@ test('aclCheck accessDenied() test - Append access implied by Write acecss', t =
   t.end()
 })
 
+// Append access implied by Write acecss without an acl:origin
+test('aclCheck accessDenied() test - Append access implied by Write acecss without acl:origin', t => {
+  let resource = $rdf.sym('https://alice.example.com/docs/file1')
+  let aclUrl = 'https://alice.example.com/docs/.acl'
+  let aclDoc = $rdf.sym(aclUrl)
+
+  const origin = $rdf.sym('https://apps.example.com')
+  const malorigin = $rdf.sym('https://mallory.example.com')
+  const store = $rdf.graph() // Quad store
+  const ACLtext = prefixes +
+  ` <#auth> a acl:Authorization;
+    acl:mode acl:Write;
+    acl:agent alice:me;
+    acl:accessTo <${resource.uri}> .
+  `
+  $rdf.parse(ACLtext, store, aclUrl, 'text/turtle')
+
+  const agent = alice
+  const directory = null
+  const modesRequired = [ ACL('Append') ]
+  const trustedOrigins = null
+
+
+  var result = !aclLogic.accessDenied(store, resource, directory, aclDoc, agent, modesRequired, origin, trustedOrigins)
+  t.ok(result, 'App should have Append access implied by Write access with an origin that is ignored')
+
+  result = !aclLogic.accessDenied(store, resource, directory, aclDoc, agent, modesRequired, malorigin, trustedOrigins)
+  t.ok(result, 'Mallorys app should have Append access with false origin')
+
+  t.end()
+})
+
 test('aclCheck accessDenied() test - Read, Write and Append', t => {
   let resource = $rdf.sym('https://alice.example.com/docs/file1')
   let aclUrl = 'https://alice.example.com/docs/.acl'


### PR DESCRIPTION
This makes it so that if no `acl:origin` is defined in the .acl file,
then no check will be done of the origin.

Fixes https://github.com/solid/node-solid-server/issues/994

To be honest, I'm not entirely certain that this is the correct way of doing this.
I'm unable to find anything about a missing `acl:origin` in the spec.
But this seems a reasonable way of handling this.

The alternative would be to add `acl:origin` predicates to all .acl files in NSS.