### PR TITLE
Match node version to solid-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@solid/acl-check",
   "version": "0.1.1",
   "engines": {
-    "node": "^8.0"
+    "node": ">=8.0"
   },
   "description": "Web Access Control check access function",
   "main": "./lib/acl-check",


### PR DESCRIPTION
Currently the `solid-server` package declares a node version of `>=8.0` while `@solid/acl-check` declares `^8.0`. If you are on node 10.x (current LTS) and you add `solid-server` as a dependency, npm will not complain about versions, start downloading `solid-server` until it tries to grab the `@solid/acl-check` dependency and then fail with `The engine "node" is incompatible with this module.` 