### PR TITLE
Disregard origin for public resources

### DIFF
--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -71,10 +71,6 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
 
   function agentOrGroupOK (auth, agent) {
     log(`   Checking auth ${auth} with agent ${agent}`)
-    if (kb.holds(auth, ACL('agentClass'), FOAF('Agent'), aclDoc)) {
-      log(`    Agent or group: Ok, its public.`)
-      return true
-    }
     if (!agent) {
       log(`    Agent or group: Fail: not public and not logged on.`)
       return false
@@ -101,6 +97,10 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
   }
 
   function agentAndAppFail (auth) {
+    if (kb.holds(auth, ACL('agentClass'), FOAF('Agent'), aclDoc)) {
+      log(`    Agent or group: Ok, its public.`)
+      return false
+    }
     if (!agentOrGroupOK(auth, agent)) {
       log('     The agent/group/public check fails')
       return 'User Unauthorized'

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -102,7 +102,7 @@ function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins
       return false
     }
     if (!agentOrGroupOK(auth, agent)) {
-      log('     The agent/group/public check fails')
+      log('     The agent/group check fails')
       return 'User Unauthorized'
     }
     if (!origin) {

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -107,6 +107,9 @@ test('acl-check accessDenied() test - default/inherited', function (t) {
   let containerAcl = $rdf.sym('https://alice.example.com/docs/.acl')
   let file1 = $rdf.sym('https://alice.example.com/docs/file1')
   let file2 = $rdf.sym('https://alice.example.com/docs/stuff/file2')
+  const origin = $rdf.sym('https://apps.example.com')
+  const malorigin = $rdf.sym('https://mallory.example.com')
+  const trustedOrigins = null
   var result
   const store = $rdf.graph()
   /*
@@ -124,6 +127,24 @@ test('acl-check accessDenied() test - default/inherited', function (t) {
 `
   $rdf.parse(containerAclText, store, containerAcl.uri, 'text/turtle')
   console.log('@@' + containerAclText + '@@@')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Read')])
+  t.ok(result, 'Alice should have read access - Public')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, bob, [ ACL('Read')])
+  t.ok(result, 'Bob should have read access too - Public')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Read')], origin, trustedOrigins)
+  t.ok(result, 'Alice should have read access regardless of origin - Public')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, bob, [ ACL('Read')], origin, trustedOrigins)
+  t.ok(result, 'Bob should have read access too regardless of origin - Public')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Read')], malorigin, trustedOrigins)
+  t.ok(result, 'Alice should have read access even with wrong origin - Public')
+
+  result = !aclLogic.accessDenied(store, file2, container, containerAcl, bob, [ ACL('Read')], malorigin, trustedOrigins)
+  t.ok(result, 'Bob should have read access too even with wrong origin - Public')
 
   result = aclLogic.accessDenied(store, file2, container, containerAcl, alice, [ ACL('Write')])
   t.ok(result, 'Alice should NOT have write acces inherited  - Public')


### PR DESCRIPTION
This patch puts the public check ahead of any origin checking, so it should fix #15.