### PR TITLE
Adding new method getTrustedModesForOrigin and added optional parameter originTrustedModes to accessDenied and checkAccess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1627,14 +1627,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1649,20 +1647,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1779,8 +1774,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1792,7 +1786,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1807,7 +1800,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1815,14 +1807,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1841,7 +1831,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1922,8 +1911,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1935,7 +1923,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2057,7 +2044,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postversion": "git push --follow-tags",
     "prepublish": "npm test && npm run build",
     "standard": "standard *.js src/*.js",
-    "tape": "tape test/unit/check-access-test.js test/unit/access-denied-test.js test/unit/configure-logger-test.js",
+    "tape": "tape test/unit/check-access-test.js test/unit/access-denied-test.js test/unit/configure-logger-test.js test/unit/get-trusted-modes-for-origin-test.js",
     "test": "npm run standard && npm run tape"
   },
   "repository": {

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -78,8 +78,8 @@ async function query (queryString, store) {
 ** @param kb A quadstore
 ** @param doc the resource (A named node) or directory for which ACL applies
 */
-function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins) {
-  return !accessDenied(kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins)
+function checkAccess (kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins, originTrustedModes) {
+  return !accessDenied(kb, doc, directory, aclDoc, agent, modesRequired, origin, trustedOrigins, originTrustedModes)
 }
 
 function modesAllowed (kb, doc, directory, aclDoc, agent, origin, trustedOrigins, originTrustedModes = []) {

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -44,17 +44,21 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
   return ok
 }
 
-async function getTrustedModesForOrigin (kb, agent, origin) {
-  if (!kb || !agent || !origin) {
-    return Promise.resolve([])
-  }
-  const result = await query(`
+async function getTrustedModesForOrigin (kb, aclDoc, doc, origin) {
+  const docAuths = kb.each(null, ACL('accessTo'), doc, aclDoc)
+  const ownerAuths = docAuths.filter(auth => kb.holds(auth, ACL('mode'), ACL('Control'), aclDoc))
+  const owners = ownerAuths.reduce((acc, auth) => acc.concat(kb.each(auth, ACL('agent'))), []) //  owners
+  const result = await Promise.all(owners.map(owner => query(`
   SELECT ?mode WHERE {
-    ${agent} ${ACL('trustedApp')} ?trustedOrigin.
+    ${owner} ${ACL('trustedApp')} ?trustedOrigin.
     ?trustedOrigin  ${ACL('origin')} ${origin};
                     ${ACL('mode')} ?mode .
-  }`, kb)
-  const trustedModes = result.map(result => result['?mode'])
+  }`, kb)))
+  let trustedModes = []
+  result.map(ownerResults => ownerResults.map(entry => {
+    console.log('entry', entry['?mode'])
+    trustedModes.push(entry['?mode'])
+  }))
   return Promise.resolve(trustedModes)
 }
 

--- a/src/acl-check.js
+++ b/src/acl-check.js
@@ -45,17 +45,17 @@ function accessDenied (kb, doc, directory, aclDoc, agent, modesRequired, origin,
 }
 
 async function getTrustedModesForOrigin (kb, agent, origin) {
-  if (!kb || !origin) {
-    return Promise.resolve({})
+  if (!kb || !agent || !origin) {
+    return Promise.resolve([])
   }
-  const queryString = `
+  const result = await query(`
   SELECT ?mode WHERE {
     ${agent} ${ACL('trustedApp')} ?trustedOrigin.
     ?trustedOrigin  ${ACL('origin')} ${origin};
                     ${ACL('mode')} ?mode .
-  }`
-  const results = await query(queryString, kb)
-  return results.map(result => result['?mode'])
+  }`, kb)
+  const trustedModes = result.map(result => result['?mode'])
+  return Promise.resolve(trustedModes)
 }
 
 async function query (queryString, store) {

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -404,7 +404,7 @@ test('aclCheck accessDenied() test - With trustedOrigins', t => {
   t.end()
 })
 
-test('aclCheck accessDenied() test - with use of acl:trustedApp', t => {
+test('aclCheck accessDenied() test - with use of originTrustedModes', t => {
   const resource = ALICE('docs/file1')
   const aclDoc = ALICE('docs/.acl')
   const aclUrl = aclDoc.uri

--- a/test/unit/access-denied-test.js
+++ b/test/unit/access-denied-test.js
@@ -6,6 +6,7 @@ const $rdf = require('rdflib')
 
 const ACL = $rdf.Namespace('http://www.w3.org/ns/auth/acl#')
 const FOAF = $rdf.Namespace('http://xmlns.com/foaf/0.1/')
+const ALICE = $rdf.Namespace('https://alice.example.com/')
 
 const prefixes = `@prefix acl: <http://www.w3.org/ns/auth/acl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
@@ -403,3 +404,34 @@ test('aclCheck accessDenied() test - With trustedOrigins', t => {
   t.end()
 })
 
+test('aclCheck accessDenied() test - with use of acl:trustedApp', t => {
+  const resource = ALICE('docs/file1')
+  const aclDoc = ALICE('docs/.acl')
+  const aclUrl = aclDoc.uri
+
+  const origin = $rdf.sym('https://apps.example.com')
+  const aclStore = $rdf.graph()
+  // grants read, write and control access to Alice
+  const ACLtext = `${prefixes}
+  <#auth> a acl:Authorization;
+    acl:mode acl:Read, acl:Write, acl:Control;
+    acl:agent alice:me;
+    acl:accessTo ${resource} .
+  `
+  $rdf.parse(ACLtext, aclStore, aclUrl, 'text/turtle')
+
+  const agent = alice
+  const directory = null
+  const trustedOrigins = []
+  const originTrustedModes = [ACL('Read'), ACL('Write')]
+
+  const readWriteModeRequired = [ACL('Read'), ACL('Write')]
+  const readWriteModeResult = aclLogic.accessDenied(aclStore, resource, directory, aclDoc, agent, readWriteModeRequired, origin, trustedOrigins, originTrustedModes)
+  t.ok(!readWriteModeResult, 'Should get access to modes when origin is listed as trusted app')
+
+  const controlModeRequired = [ACL('Control')]
+  const controlModeResult = aclLogic.accessDenied(aclStore, resource, directory, aclDoc, agent, controlModeRequired, origin, trustedOrigins, originTrustedModes)
+  t.ok(controlModeResult, 'All Required Access Modes Not Granted', 'Correct reason')
+
+  t.end()
+})

--- a/test/unit/get-trusted-modes-for-origin-test.js
+++ b/test/unit/get-trusted-modes-for-origin-test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const test = require('tape')
+const aclLogic = require('../../src/acl-check')
+const $rdf = require('rdflib')
+
+const ACL = $rdf.Namespace('http://www.w3.org/ns/auth/acl#')
+const ALICE = $rdf.Namespace('https://alice.example.com/')
+const alice = ALICE('#me')
+
+const prefixes = `
+@prefix acl: ${ACL()} .
+@prefix alice: ${ALICE('#')} .
+`
+
+test('aclCheck getTrustedModesForOirign() test', t => {
+  const origin = $rdf.sym('https://apps.example.com')
+  const agent = alice
+  const agentStore = $rdf.graph()
+  const agentText = `${prefixes}
+  ${agent} acl:trustedApp [  acl:origin ${origin};
+                             acl:mode acl:Read, acl:Write].
+  `
+  $rdf.parse(agentText, agentStore, agent.uri, 'text/turtle')
+
+  aclLogic.getTrustedModesForOrigin(agentStore, agent, origin).then(result => {
+    t.deepEqual(result, [ACL('Read'), ACL('Write')], 'Should get a list of modes')
+    t.end()
+  })
+})

--- a/test/unit/get-trusted-modes-for-origin-test.js
+++ b/test/unit/get-trusted-modes-for-origin-test.js
@@ -13,7 +13,7 @@ const prefixes = `
 @prefix alice: ${ALICE('#')} .
 `
 
-test('aclCheck getTrustedModesForOirign() test', t => {
+test('aclCheck getTrustedModesForOrigin() getting trusted modes from agentStore', t => {
   const origin = $rdf.sym('https://apps.example.com')
   const agent = alice
   const agentStore = $rdf.graph()

--- a/test/unit/get-trusted-modes-for-origin-test.js
+++ b/test/unit/get-trusted-modes-for-origin-test.js
@@ -36,7 +36,7 @@ test('aclCheck getTrustedModesForOrigin() getting trusted modes from publisherSt
   `
   $rdf.parse(publisherText, publisherStore, publisher.uri, 'text/turtle')
 
-  aclLogic.getTrustedModesForOrigin(publisherStore, aclDoc, doc, origin).then(result => {
+  aclLogic.getTrustedModesForOrigin(publisherStore, aclDoc, doc, origin, Promise.resolve.bind(Promise)).then(result => {
     t.deepEqual(result, [ACL('Read'), ACL('Write')], 'Should get a list of modes')
     t.end()
   })


### PR DESCRIPTION
Makes use of the proposed property `app:trustedApp`. Made `getTrustedModesForOrigin` async since it relies on `$rdf.SPARQLToQuery`.

The optional parameter `originTrustedModes` for `accessDenied` and `checkAccess` allows user to list which modes the origin is trusted to access.

The idea is that the server can get the list of trusted modes for a given origin, and supply that list in `accessDenied` or `checkAccess`.

This should fix https://github.com/solid/acl-check/issues/17